### PR TITLE
feature: migrating from completions to responses api

### DIFF
--- a/db.js
+++ b/db.js
@@ -43,6 +43,24 @@ function initDb() {
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
         )`);
+
+        // Migration to add last_response_id if missing
+        db.all("PRAGMA table_info(conversations)", (err, rows) => {
+            if (err) {
+                console.error("Error checking table info:", err);
+                return;
+            }
+            const hasColumn = rows.some(row => row.name === 'last_response_id');
+            if (!hasColumn) {
+                db.run("ALTER TABLE conversations ADD COLUMN last_response_id TEXT", (err) => {
+                    if (err) {
+                        console.error("Error adding last_response_id column:", err);
+                    } else {
+                        console.log("Successfully added last_response_id column to conversations.");
+                    }
+                });
+            }
+        });
     });
 }
 

--- a/scripts/fix_db.js
+++ b/scripts/fix_db.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const fs = require('fs');
+const sqlite3 = require('sqlite3').verbose();
+const os = require('os');
+
+const appName = 'GERAI'; // Based on productName
+const dbName = 'gerai.db';
+
+// Try typical Electron userData paths
+const candidates = [
+    path.join(os.homedir(), 'Library', 'Application Support', appName, dbName),
+    path.join(os.homedir(), 'Library', 'Application Support', 'gerai', dbName),
+    path.join(os.homedir(), 'AppData', 'Roaming', appName, dbName),
+    path.join(os.homedir(), 'AppData', 'Roaming', 'gerai', dbName),
+    path.resolve(__dirname, '../gerai.db')
+];
+
+let targetDb = null;
+for (const p of candidates) {
+    if (fs.existsSync(p)) {
+        targetDb = p;
+        break;
+    }
+}
+
+if (!targetDb) {
+    console.log("Could not find DB in standard locations for OS:", process.platform);
+    process.exit(1);
+}
+
+console.log("Checking DB at:", targetDb);
+
+const db = new sqlite3.Database(targetDb);
+db.all("PRAGMA table_info(conversations)", (err, rows) => {
+    if (err) {
+        console.error(err);
+        return;
+    }
+    console.log("Columns:", rows.map(r => r.name));
+    const hasCol = rows.some(r => r.name === 'last_response_id');
+    console.log("Has last_response_id:", hasCol);
+    if (!hasCol) {
+        console.log("Adding column...");
+        db.run("ALTER TABLE conversations ADD COLUMN last_response_id TEXT", (err) => {
+            if (err) console.error(err);
+            else console.log("Success: Added last_response_id column.");
+        });
+    } else {
+        console.log("Column already exists.");
+    }
+});

--- a/scripts/inspect_db.js
+++ b/scripts/inspect_db.js
@@ -1,0 +1,19 @@
+const path = require('path');
+const fs = require('fs');
+const sqlite3 = require('sqlite3').verbose();
+const os = require('os');
+
+const appName = 'GERAI';
+const dbName = 'gerai.db';
+const candidate = path.join(os.homedir(), 'Library', 'Application Support', appName, dbName);
+
+if (!fs.existsSync(candidate)) {
+    console.log("DB not found at", candidate);
+    process.exit(1);
+}
+
+const db = new sqlite3.Database(candidate);
+db.all("SELECT id, title, last_response_id FROM conversations", (err, rows) => {
+    if (err) console.error(err);
+    else console.log(JSON.stringify(rows, null, 2));
+});

--- a/services/openai.js
+++ b/services/openai.js
@@ -1,28 +1,59 @@
-const OpenAI = require('openai');
+const { OpenAI } = require('openai');
 
-async function getOpenAIResponse(apiKey, messages, model = 'gpt-5-mini') {
+const fs = require('fs');
+const path = require('path');
+
+async function getOpenAIResponse(apiKey, input, model = 'gpt-5-mini', instructions, previousResponseId) {
     try {
         console.log('--- OpenAI Request ---');
         console.log('Model:', model);
-        console.log('Messages:', JSON.stringify(messages, null, 2));
+        console.log('Input:', input);
+        if (previousResponseId) console.log('Previous Response ID:', previousResponseId);
 
-        const openai = new OpenAI({
+        const client = new OpenAI({
             apiKey: apiKey,
             dangerouslyAllowBrowser: false
         });
 
-        const completion = await openai.chat.completions.create({
+        const params = {
             model: model,
-            messages: messages,
-        });
+            input: input,
+            store: true,
+        };
+
+        if (instructions) {
+            params.instructions = instructions;
+        }
+
+        if (previousResponseId) {
+            params.previous_response_id = previousResponseId;
+        }
+
+        const response = await client.responses.create(params);
+
+        // Debug logging to file
+        const logPath = path.resolve(__dirname, '../openai_debug.log');
+        const debugInfo = {
+            timestamp: new Date().toISOString(),
+            responseKeys: Object.keys(response),
+            responseId: response.response_id,
+            id: response.id,
+            output_text: response.output_text
+        };
+        fs.appendFileSync(logPath, JSON.stringify(debugInfo, null, 2) + '\n');
 
         console.log('--- OpenAI Response ---');
-        console.log('ID:', completion.id);
-        console.log('Usage:', completion.usage);
+        console.log('ID:', response.response_id || response.id);
+        console.log('Output:', response.output_text);
 
-        return completion.choices[0].message.content;
+        return {
+            output_text: response.output_text,
+            response_id: response.response_id || response.id
+        };
     } catch (error) {
         console.error('OpenAI API Error:', error);
+        const logPath = path.resolve(__dirname, '../openai_debug.log');
+        fs.appendFileSync(logPath, `ERROR: ${error.message}\n${error.stack}\n`);
         throw new Error('Failed to fetch response from OpenAI');
     }
 }


### PR DESCRIPTION
Title
Migrate OpenAI integration from Chat Completions to Responses API (threaded)

Summary
This PR switches our OpenAI calls to the Responses API and threads conversations using response_id. It also adds a new DB column to persist the last_response_id per conversation, adjusts message flow in Electron, and includes small utilities to inspect/fix local DBs.

What’s changed
•  OpenAI integration
◦  Switch to Responses API: client.responses.create with input instead of building a messages array (services/openai.js).
◦  Threading: pass previous_response_id to continue a conversation; return { output_text, response_id }.
◦  Initial instructions: only sent on the first turn (when no last_response_id). Uses user’s “System Prompt” or a safe default.
◦  Logging: append minimal debug info (ids, output_text) to openai_debug.log.
•  Electron flow
◦  IPC handler now sends the user’s latest message and optional instructions, not full history (electron/main.js).
◦  Persists new response_id to conversations.last_response_id to maintain thread state.
◦  Title heuristic: if title is “New Chat” and early in the convo, set from first user message.
•  Database
◦  Schema migration: adds conversations.last_response_id TEXT if missing (db.js).
◦  Utilities: scripts/inspect_db.js and scripts/fix_db.js to inspect/add the column for existing installs.
•  Defaults
◦  UI default model remains gpt-5-nano (src/constants/models.js). Service helper still defaults to gpt-5-mini when called directly but Electron passes the selected model.

Why
•  Responses API provides a unified, thread-aware interface and aligns us with the newer OpenAI endpoints.
•  Storing last_response_id allows lightweight continuation without reconstructing message history.

Migration/Deployment notes
•  The column is added automatically on app start. If you need to repair an older DB manually:
◦  node scripts/inspect_db.js
◦  node scripts/fix_db.js
•  Debug file location: openai_debug.log (repo root). Contains ids and output_text; consider clearing before packaging a release.

Testing
1) Fresh start
•  npm install
•  npm run dev
•  Create a new chat, set API key and optional System Prompt.
•  Send a message; expect an assistant reply and conversations.last_response_id to be populated.
2) Threading
•  Send a second message in the same chat; verify a new response, and last_response_id updates.
3) DB checks
•  Run node scripts/inspect_db.js and confirm last_response_id exists and is non-null after a chat.
4) Title behavior
•  On first few messages of a new chat, title should reflect the first user message prefix.

Potential risks
•  Function signature change: getOpenAIResponse now returns an object; all internal callers updated.
•  Debug logging includes output_text; acceptable for dev, but we should gate or redact for production builds.

Out of scope / follow-ups
•  Gate debug logging behind an env flag.
•  Optionally store full thread metadata if we need richer resume scenarios.